### PR TITLE
Feat: i18n support for default interface

### DIFF
--- a/packages/docs/src/theme/Root.js
+++ b/packages/docs/src/theme/Root.js
@@ -4,7 +4,7 @@ import { MDXProvider } from '@mdx-js/react'
 
 import { IntegrationProfile } from '../components/integration-profile'
 
-import { ConsentManager, ConsentManagerForm } from '@consent-manager/core'
+import { ConsentManager } from '@consent-manager/core'
 import createPersistedState from 'use-persisted-state'
 
 import { mapboxIntegration } from '@consent-manager/integration-mapbox'
@@ -19,7 +19,7 @@ import { hubspotIntegration } from '@consent-manager/integration-hubspot'
 import { linkedinIntegration } from '@consent-manager/integration-linkedin'
 
 import {
-  InterfaceDefault,
+  ConsentManagerDefaultInterface,
   FallbackComponent,
 } from '@consent-manager/interface-default'
 import '@consent-manager/interface-default/dist/default.min.css'
@@ -69,11 +69,9 @@ function Root({ children }) {
           <FallbackComponent {...props} Button={Button} />
         )}
       >
-        {children}
-        <ConsentManagerForm
-          formComponent={InterfaceDefault}
-          SubmitButton={Button}
-        />
+        <ConsentManagerDefaultInterface>
+          {children}
+        </ConsentManagerDefaultInterface>
       </ConsentManager>
     </MDXProvider>
   )

--- a/packages/interface-default/package.json
+++ b/packages/interface-default/package.json
@@ -48,6 +48,8 @@
   "license": "MIT",
   "dependencies": {
     "@consent-manager/core": "*",
+    "@lingui/core": "^3.8.9",
+    "@lingui/react": "^3.8.9",
     "@react-icons/all-files": "^4.1.0",
     "activity-detector-ssr": "^3.0.0",
     "body-scroll-lock": "^3.1.5",

--- a/packages/interface-default/src/form.tsx
+++ b/packages/interface-default/src/form.tsx
@@ -9,11 +9,12 @@ import {
 import defaultStyles from './index.module.css'
 import { Switch as DefaultSwitch, SwitchProps } from './switch'
 import { Integration } from './integration'
-import { Styles, SubmitButtonProps } from './index'
+import { Styles, SubmitButtonProps, TransProps } from './index'
 
 export interface ConsentFormProps extends DecisionsFormProps {
   styles: Styles
   setShowForm: Function
+  Trans: React.ComponentType<TransProps>
   Switch?: React.ComponentType<SwitchProps>
   SubmitButton?: React.ComponentType<SubmitButtonProps>
 }
@@ -31,6 +32,7 @@ export const ConsentForm: React.FC<ConsentFormProps> = ({
   initialValues,
   onSubmit,
   setShowForm,
+  Trans,
   styles = defaultStyles,
   Switch = DefaultSwitch,
   SubmitButton = DefaultSubmitButton,
@@ -68,20 +70,27 @@ export const ConsentForm: React.FC<ConsentFormProps> = ({
       render={({ handleSubmit }) => (
         <form onSubmit={handleSubmit}>
           <SubmitButton className={clsx(styles.submitButton)}>
-            Close and save
+            <Trans id="consent-manager.form.button">Close and save</Trans>
           </SubmitButton>
-          <h2>Website Settings</h2>
-          <p>Some features are disabled by default to protect your privacy:</p>
+          <h2>
+            <Trans id="consent-manager.form.headline">Website Settings</Trans>
+          </h2>
+          <p>
+            <Trans id="consent-manager.form.description">
+              Some features are disabled by default to protect your privacy:
+            </Trans>
+          </p>
           {integrations.map((integration: IntegrationConfigOptions) => (
             <Integration
               styles={styles}
               key={integration.id}
               Switch={Switch}
+              Trans={Trans}
               {...integration}
             />
           ))}
           <SubmitButton className={clsx(styles.submitButton)}>
-            Close and save
+            <Trans id="consent-manager.form.button">Close and save</Trans>
           </SubmitButton>
         </form>
       )}

--- a/packages/interface-default/src/form.tsx
+++ b/packages/interface-default/src/form.tsx
@@ -5,16 +5,16 @@ import {
   DecisionsFormProps,
   IntegrationConfigOptions,
 } from '@consent-manager/core'
+import { Trans } from '@lingui/react'
 
 import defaultStyles from './index.module.css'
 import { Switch as DefaultSwitch, SwitchProps } from './switch'
 import { Integration } from './integration'
-import { Styles, SubmitButtonProps, TransProps } from './index'
+import { Styles, SubmitButtonProps } from './index'
 
 export interface ConsentFormProps extends DecisionsFormProps {
   styles: Styles
   setShowForm: Function
-  Trans: React.ComponentType<TransProps>
   Switch?: React.ComponentType<SwitchProps>
   SubmitButton?: React.ComponentType<SubmitButtonProps>
 }
@@ -32,7 +32,6 @@ export const ConsentForm: React.FC<ConsentFormProps> = ({
   initialValues,
   onSubmit,
   setShowForm,
-  Trans,
   styles = defaultStyles,
   Switch = DefaultSwitch,
   SubmitButton = DefaultSubmitButton,
@@ -70,27 +69,30 @@ export const ConsentForm: React.FC<ConsentFormProps> = ({
       render={({ handleSubmit }) => (
         <form onSubmit={handleSubmit}>
           <SubmitButton className={clsx(styles.submitButton)}>
-            <Trans id="consent-manager.form.button">Close and save</Trans>
+            <Trans id="consent-manager.form.button" message="Close and save" />
           </SubmitButton>
           <h2>
-            <Trans id="consent-manager.form.headline">Website Settings</Trans>
+            <Trans
+              id="consent-manager.form.headline"
+              message="Website Settings"
+            />
           </h2>
           <p>
-            <Trans id="consent-manager.form.description">
-              Some features are disabled by default to protect your privacy:
-            </Trans>
+            <Trans
+              id="consent-manager.form.description"
+              message="Some features are disabled by default to protect your privacy:"
+            />
           </p>
           {integrations.map((integration: IntegrationConfigOptions) => (
             <Integration
               styles={styles}
               key={integration.id}
               Switch={Switch}
-              Trans={Trans}
               {...integration}
             />
           ))}
           <SubmitButton className={clsx(styles.submitButton)}>
-            <Trans id="consent-manager.form.button">Close and save</Trans>
+            <Trans id="consent-manager.form.button" message="Close and save" />
           </SubmitButton>
         </form>
       )}

--- a/packages/interface-default/src/index.tsx
+++ b/packages/interface-default/src/index.tsx
@@ -1,211 +1,58 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
-import clsx from 'clsx'
-import { CSSTransition } from 'react-transition-group'
-import { FiChevronUp } from '@react-icons/all-files/fi/FiChevronUp'
-
+import React, { useMemo } from 'react'
+import { ConsentManagerForm } from '@consent-manager/core'
 import {
-  disableBodyScroll,
-  enableBodyScroll,
-  clearAllBodyScrollLocks,
-} from 'body-scroll-lock'
-import { use100vh } from 'react-div-100vh'
+  setupI18n,
+  Locale,
+  Locales,
+  AllMessages,
+  AllLocaleData,
+} from '@lingui/core'
+import { I18nProvider } from '@lingui/react'
+import { I18n } from '@lingui/core'
 
-import {
-  DecisionsFormProps,
-  useConsentFormVisible,
-} from '@consent-manager/core'
+import { Interface, InterfaceProps } from './interface'
 
-import { Switch as DefaultSwitch, SwitchProps } from './switch'
-import defaultStyles from './index.module.css'
-import defaultAnimationStyles from './animation-slide.module.css'
-import { Introduction } from './introduction'
-import { ConsentForm as DefaultForm, ConsentFormProps } from './form'
-import { Backdrop } from './backdrop'
-
-import {
-  ToggleButton as DefaultToggleButton,
-  ToggleButtonProps,
-} from './toggle-button'
+export { ToggleButtonProps } from './toggle-button'
+export { InterfaceProps, SubmitButtonProps, ToggleIconProps } from './interface'
 
 export interface Styles {
   [key: string]: string
 }
 
-export interface ToggleIconProps {
-  [key: string]: string
+// Copy of https://github.com/lingui/js-lingui/blob/main/packages/core/src/i18n.ts#L43
+interface setupI18nProps {
+  locale?: Locale
+  locales?: Locales
+  messages?: AllMessages
+  localeData?: AllLocaleData
+  missing?: string | ((message: any, id: any) => string)
 }
 
-export interface SubmitButtonProps {
-  [key: string]: unknown
+interface ConsentManagerDefaultInterfaceProps extends InterfaceProps {
+  linguiConfig: setupI18nProps
+  i18n: I18n
 }
 
-export interface TransProps {
-  id?: string
-  [key: string]: unknown
-}
-
-export interface InterfaceDefaultProps extends DecisionsFormProps {
-  slideDuration: number
-  renderBackdrop: boolean
-  styles?: Styles
-  animationStyles?: Styles
-  Trans?: React.ComponentType<TransProps>
-  ToggleButton?: React.ComponentType<ToggleButtonProps>
-  ToggleIcon?: React.ComponentType<ToggleIconProps>
-  Switch?: React.ComponentType<SwitchProps>
-  SubmitButton?: React.ComponentType<SubmitButtonProps>
-  Form?: React.ComponentType<ConsentFormProps>
-}
-
-const DefaultSubmitButton: React.FC<SubmitButtonProps> = props => (
-  <button {...props} />
-)
-
-const DefaultTrans: React.FC<TransProps> = ({ children }) => <>{children}</>
-
-export const InterfaceDefault: React.FC<InterfaceDefaultProps> = ({
-  integrations,
-  initialValues,
-  onSubmit,
-  slideDuration = 700,
-  renderBackdrop = true,
-  styles = defaultStyles,
-  Trans = DefaultTrans,
-  ToggleIcon = FiChevronUp,
-  ToggleButton = DefaultToggleButton,
-  Switch = DefaultSwitch,
-  SubmitButton = DefaultSubmitButton,
-  Form = DefaultForm,
-  animationStyles = defaultAnimationStyles,
+export const ConsentManagerDefaultInterface: React.FC<ConsentManagerDefaultInterfaceProps> = ({
+  i18n,
+  linguiConfig = {
+    locale: 'en',
+    // By defining messages for the en locale you can override the default copy
+    // messages: { en: { 'consent-manager.form.title': 'Privacy Settings' } },
+  },
+  children,
+  ...props
 }) => {
-  const hasPendingDecisions = useConsentFormVisible()
-
-  const [needsIntroduction, setNeedsIntroduction] = useState(
-    hasPendingDecisions
-  )
-
-  const introductionFinished = useCallback(() => {
-    setNeedsIntroduction(false)
-  }, [setNeedsIntroduction])
-
-  const [showForm, setShowForm] = useState(false)
-  const formContainerRef = useRef<HTMLDivElement>(null)
-
-  const toggleControlForm = useCallback(
-    e => {
-      e.preventDefault()
-      setShowForm(v => !v)
-    },
-    [setShowForm]
-  )
-
-  // Freeze scroll when form is shown
-  useEffect(() => {
-    const target: HTMLDivElement | null = formContainerRef.current
-
-    if (!target) {
-      return
-    }
-
-    if (showForm) {
-      disableBodyScroll(target)
-      target.scrollTo({ top: 0 })
-    }
-
-    if (!showForm) {
-      enableBodyScroll(target)
-    }
-
-    return clearAllBodyScrollLocks
-  }, [showForm, formContainerRef])
-
-  // Get 100vh on mobile browsers as well
-  const viewportHeight = use100vh()
-
-  const handleEsc = useCallback(
-    e => {
-      if (showForm && e.keyCode === 27) {
-        e.preventDefault()
-        setShowForm(false)
-      }
-    },
-    [showForm]
-  )
-
-  // Allow close on ESC key
-  useEffect(() => {
-    window.addEventListener('keydown', handleEsc)
-
-    return () => {
-      window.removeEventListener('keydown', handleEsc)
-    }
-  }, [handleEsc])
-
-  // Check if component was mounted for SSR
-  const [isMounted, setIsMounted] = useState(false)
-  useEffect(() => setIsMounted(true), [setIsMounted])
-
-  // Do not render the interface on SSR.
-  if (!isMounted) {
-    return null
-  }
+  // Use custom i18n instance for multi locale support or use default setup
+  const i18nInstance = useMemo(() => {
+    return i18n || setupI18n(linguiConfig)
+  }, [linguiConfig, i18n])
 
   return (
-    <div className={clsx(styles.wrapper)} id="consent-control-ui">
-      {needsIntroduction && (
-        <Introduction
-          introductionFinished={introductionFinished}
-          slideDuration={slideDuration}
-          Trans={Trans}
-        />
-      )}
-      {renderBackdrop && (
-        <Backdrop
-          show={showForm}
-          fadeDuration={slideDuration}
-          styles={styles}
-        />
-      )}
-      <CSSTransition
-        in={showForm}
-        timeout={slideDuration}
-        classNames={animationStyles}
-        unmountOnExit
-        mountOnEnter
-      >
-        <div
-          className={clsx(styles.pane, styles.slide)}
-          style={{
-            transitionDuration: `${slideDuration}ms`,
-          }}
-        >
-          <div
-            className={clsx(styles.form)}
-            style={{
-              maxHeight: viewportHeight ? `${viewportHeight}px` : 'null',
-            }}
-            ref={formContainerRef}
-          >
-            <Form
-              styles={styles}
-              onSubmit={onSubmit}
-              integrations={integrations}
-              initialValues={initialValues}
-              setShowForm={setShowForm}
-              Switch={Switch}
-              SubmitButton={SubmitButton}
-              Trans={Trans}
-            />
-          </div>
-        </div>
-      </CSSTransition>
-      <ToggleButton
-        ToggleIcon={ToggleIcon}
-        styles={styles}
-        showForm={showForm}
-        toggleControlForm={toggleControlForm}
-      />
-    </div>
+    <I18nProvider i18n={i18nInstance}>
+      {children}
+      <ConsentManagerForm formComponent={Interface} {...props} />
+    </I18nProvider>
   )
 }
 

--- a/packages/interface-default/src/index.tsx
+++ b/packages/interface-default/src/index.tsx
@@ -36,7 +36,12 @@ export interface ToggleIconProps {
 }
 
 export interface SubmitButtonProps {
-  [key: string]: string
+  [key: string]: unknown
+}
+
+export interface TransProps {
+  id?: string
+  [key: string]: unknown
 }
 
 export interface InterfaceDefaultProps extends DecisionsFormProps {
@@ -44,6 +49,7 @@ export interface InterfaceDefaultProps extends DecisionsFormProps {
   renderBackdrop: boolean
   styles?: Styles
   animationStyles?: Styles
+  Trans?: React.ComponentType<TransProps>
   ToggleButton?: React.ComponentType<ToggleButtonProps>
   ToggleIcon?: React.ComponentType<ToggleIconProps>
   Switch?: React.ComponentType<SwitchProps>
@@ -55,6 +61,8 @@ const DefaultSubmitButton: React.FC<SubmitButtonProps> = props => (
   <button {...props} />
 )
 
+const DefaultTrans: React.FC<TransProps> = ({ children }) => <>{children}</>
+
 export const InterfaceDefault: React.FC<InterfaceDefaultProps> = ({
   integrations,
   initialValues,
@@ -62,6 +70,7 @@ export const InterfaceDefault: React.FC<InterfaceDefaultProps> = ({
   slideDuration = 700,
   renderBackdrop = true,
   styles = defaultStyles,
+  Trans = DefaultTrans,
   ToggleIcon = FiChevronUp,
   ToggleButton = DefaultToggleButton,
   Switch = DefaultSwitch,
@@ -147,6 +156,7 @@ export const InterfaceDefault: React.FC<InterfaceDefaultProps> = ({
         <Introduction
           introductionFinished={introductionFinished}
           slideDuration={slideDuration}
+          Trans={Trans}
         />
       )}
       {renderBackdrop && (
@@ -184,6 +194,7 @@ export const InterfaceDefault: React.FC<InterfaceDefaultProps> = ({
               setShowForm={setShowForm}
               Switch={Switch}
               SubmitButton={SubmitButton}
+              Trans={Trans}
             />
           </div>
         </div>

--- a/packages/interface-default/src/integration.tsx
+++ b/packages/interface-default/src/integration.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import { Field } from 'react-final-form'
 import clsx from 'clsx'
-
+import { Trans } from '@lingui/react'
 import { IntegrationConfigOptions } from '@consent-manager/core'
 
 import { Switch as DefaultSwitch, SwitchProps } from './switch'
 import defaultStyles from './index.module.css'
 
-export interface IntgrationProps extends IntegrationConfigOptions {
+export interface IntegrationProps extends IntegrationConfigOptions {
   Switch?: React.ComponentType<SwitchProps>
 }
 
-export const Integration: React.FC<IntgrationProps> = ({
+export const Integration: React.FC<IntegrationProps> = ({
   styles = defaultStyles,
   Switch = DefaultSwitch,
   id,
@@ -32,15 +32,29 @@ export const Integration: React.FC<IntgrationProps> = ({
         }}
       >
         <Icon className={clsx(styles.integrationIcon)} />
-        <span className={clsx(styles.integrationTitle)}>{title}</span>
+        <span className={clsx(styles.integrationTitle)}>
+          <Trans
+            id={`consent-manager.integration.${id}.title`}
+            message={title}
+          />
+        </span>
       </div>
     </Field>
     <p className={clsx(styles.integrationDescription)}>
-      {description}
+      <Trans
+        id={`consent-manager.integration.${id}.description`}
+        message={description}
+      />
       <br />
-      <a href={privacyPolicyUrl} rel="noreferrer" target="_blank">
-        Learn more about the privacy policy of {title}
-      </a>
+      <Trans
+        id={`consent-manager.integration.${id}.privacy-policy`}
+        message="<0>Learn more about the privacy policy of <1/>.</0>"
+        components={[
+          // eslint-disable-next-line jsx-a11y/anchor-has-content
+          <a href={privacyPolicyUrl} rel="noreferrer" target="_blank" />,
+          <>{title}</>,
+        ]}
+      />
     </p>
   </div>
 )

--- a/packages/interface-default/src/interface.tsx
+++ b/packages/interface-default/src/interface.tsx
@@ -195,5 +195,3 @@ export const Interface: React.FC<InterfaceProps> = ({
     </div>
   )
 }
-
-export { FallbackComponent } from './fallback-component'

--- a/packages/interface-default/src/interface.tsx
+++ b/packages/interface-default/src/interface.tsx
@@ -1,0 +1,199 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import clsx from 'clsx'
+import { CSSTransition } from 'react-transition-group'
+import { FiChevronUp } from '@react-icons/all-files/fi/FiChevronUp'
+
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+  clearAllBodyScrollLocks,
+} from 'body-scroll-lock'
+import { use100vh } from 'react-div-100vh'
+
+import {
+  DecisionsFormProps,
+  useConsentFormVisible,
+} from '@consent-manager/core'
+
+import { Switch as DefaultSwitch, SwitchProps } from './switch'
+import defaultStyles from './index.module.css'
+import defaultAnimationStyles from './animation-slide.module.css'
+import { Introduction } from './introduction'
+import { ConsentForm as DefaultForm, ConsentFormProps } from './form'
+import { Backdrop } from './backdrop'
+
+import {
+  ToggleButton as DefaultToggleButton,
+  ToggleButtonProps,
+} from './toggle-button'
+
+import { Styles } from './index'
+
+export interface ToggleIconProps {
+  [key: string]: unknown
+}
+
+export interface SubmitButtonProps {
+  [key: string]: unknown
+}
+
+export interface InterfaceProps extends DecisionsFormProps {
+  slideDuration?: number
+  renderBackdrop?: boolean
+  styles?: Styles
+  animationStyles?: Styles
+  ToggleButton?: React.ComponentType<ToggleButtonProps>
+  ToggleIcon?: React.ComponentType<ToggleIconProps>
+  Switch?: React.ComponentType<SwitchProps>
+  SubmitButton?: React.ComponentType<SubmitButtonProps>
+  Form?: React.ComponentType<ConsentFormProps>
+}
+
+const DefaultSubmitButton: React.FC<SubmitButtonProps> = props => (
+  <button {...props} />
+)
+
+export const Interface: React.FC<InterfaceProps> = ({
+  integrations,
+  initialValues,
+  onSubmit,
+  slideDuration = 700,
+  renderBackdrop = true,
+  styles = defaultStyles,
+  ToggleIcon = FiChevronUp,
+  ToggleButton = DefaultToggleButton,
+  Switch = DefaultSwitch,
+  SubmitButton = DefaultSubmitButton,
+  Form = DefaultForm,
+  animationStyles = defaultAnimationStyles,
+}) => {
+  const hasPendingDecisions = useConsentFormVisible()
+
+  const [needsIntroduction, setNeedsIntroduction] = useState(
+    hasPendingDecisions
+  )
+
+  const introductionFinished = useCallback(() => {
+    setNeedsIntroduction(false)
+  }, [setNeedsIntroduction])
+
+  const [showForm, setShowForm] = useState(false)
+  const formContainerRef = useRef<HTMLDivElement>(null)
+
+  const toggleControlForm = useCallback(
+    e => {
+      e.preventDefault()
+      setShowForm(v => !v)
+    },
+    [setShowForm]
+  )
+
+  // Freeze scroll when form is shown
+  useEffect(() => {
+    const target: HTMLDivElement | null = formContainerRef.current
+
+    if (!target) {
+      return
+    }
+
+    if (showForm) {
+      disableBodyScroll(target)
+      target.scrollTo({ top: 0 })
+    }
+
+    if (!showForm) {
+      enableBodyScroll(target)
+    }
+
+    return clearAllBodyScrollLocks
+  }, [showForm, formContainerRef])
+
+  // Get 100vh on mobile browsers as well
+  const viewportHeight = use100vh()
+
+  const handleEsc = useCallback(
+    e => {
+      if (showForm && e.keyCode === 27) {
+        e.preventDefault()
+        setShowForm(false)
+      }
+    },
+    [showForm]
+  )
+
+  // Allow close on ESC key
+  useEffect(() => {
+    window.addEventListener('keydown', handleEsc)
+
+    return () => {
+      window.removeEventListener('keydown', handleEsc)
+    }
+  }, [handleEsc])
+
+  // Check if component was mounted for SSR
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => setIsMounted(true), [setIsMounted])
+
+  // Do not render the interface on SSR.
+  if (!isMounted) {
+    return null
+  }
+
+  return (
+    <div className={clsx(styles.wrapper)} id="consent-control-ui">
+      {needsIntroduction && (
+        <Introduction
+          introductionFinished={introductionFinished}
+          slideDuration={slideDuration}
+        />
+      )}
+      {renderBackdrop && (
+        <Backdrop
+          show={showForm}
+          fadeDuration={slideDuration}
+          styles={styles}
+        />
+      )}
+      <CSSTransition
+        in={showForm}
+        timeout={slideDuration}
+        classNames={animationStyles}
+        unmountOnExit
+        mountOnEnter
+      >
+        <div
+          className={clsx(styles.pane, styles.slide)}
+          style={{
+            transitionDuration: `${slideDuration}ms`,
+          }}
+        >
+          <div
+            className={clsx(styles.form)}
+            style={{
+              maxHeight: viewportHeight ? `${viewportHeight}px` : 'null',
+            }}
+            ref={formContainerRef}
+          >
+            <Form
+              styles={styles}
+              onSubmit={onSubmit}
+              integrations={integrations}
+              initialValues={initialValues}
+              setShowForm={setShowForm}
+              Switch={Switch}
+              SubmitButton={SubmitButton}
+            />
+          </div>
+        </div>
+      </CSSTransition>
+      <ToggleButton
+        ToggleIcon={ToggleIcon}
+        styles={styles}
+        showForm={showForm}
+        toggleControlForm={toggleControlForm}
+      />
+    </div>
+  )
+}
+
+export { FallbackComponent } from './fallback-component'

--- a/packages/interface-default/src/introduction.tsx
+++ b/packages/interface-default/src/introduction.tsx
@@ -5,10 +5,11 @@ import createActivityDetector from 'activity-detector-ssr'
 
 import defaultStyles from './index.module.css'
 import defaultAnimationStyles from './animation-slide.module.css'
-import { Styles } from './index'
+import { Styles, TransProps } from './index'
 
 export interface IntroductionProps {
   introductionFinished: Function
+  Trans: React.ComponentType<TransProps>
   styles?: Styles
   animationStyles?: Styles
   slideDuration: number
@@ -28,6 +29,7 @@ export const Introduction: React.FC<IntroductionProps> = ({
   slideDuration,
   noActionDelay = 4000,
   visibleDuration = 6000,
+  Trans,
 }) => {
   const [show, setShow] = useState(false)
   const [isIdle, setIsIdle] = React.useState(false)
@@ -75,7 +77,7 @@ export const Introduction: React.FC<IntroductionProps> = ({
         style={{ transitionDuration: `${slideDuration}ms` }}
       >
         <div className={clsx(styles.introduction, styles.content)}>
-          Some features got disabled in respect of your privacy.
+          <Trans>Some features got disabled in respect of your privacy.</Trans>
         </div>
       </div>
     </CSSTransition>

--- a/packages/interface-default/src/introduction.tsx
+++ b/packages/interface-default/src/introduction.tsx
@@ -2,14 +2,13 @@ import React, { useEffect, useState } from 'react'
 import clsx from 'clsx'
 import { CSSTransition } from 'react-transition-group'
 import createActivityDetector from 'activity-detector-ssr'
-
+import { Trans } from '@lingui/react'
 import defaultStyles from './index.module.css'
 import defaultAnimationStyles from './animation-slide.module.css'
-import { Styles, TransProps } from './index'
+import { Styles } from './index'
 
 export interface IntroductionProps {
   introductionFinished: Function
-  Trans: React.ComponentType<TransProps>
   styles?: Styles
   animationStyles?: Styles
   slideDuration: number
@@ -29,7 +28,6 @@ export const Introduction: React.FC<IntroductionProps> = ({
   slideDuration,
   noActionDelay = 4000,
   visibleDuration = 6000,
-  Trans,
 }) => {
   const [show, setShow] = useState(false)
   const [isIdle, setIsIdle] = React.useState(false)
@@ -77,7 +75,10 @@ export const Introduction: React.FC<IntroductionProps> = ({
         style={{ transitionDuration: `${slideDuration}ms` }}
       >
         <div className={clsx(styles.introduction, styles.content)}>
-          <Trans>Some features got disabled in respect of your privacy.</Trans>
+          <Trans
+            id="consent-manager.introduction"
+            message="Some features got disabled in respect of your privacy."
+          />
         </div>
       </div>
     </CSSTransition>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10945,7 +10945,7 @@ make-fetch-happen@^5.0.0:
 
 make-plural@^6.2.2:
   version "6.2.2"
-  resolved "http://localhost:4873/make-plural/-/make-plural-6.2.2.tgz#beb5fd751355e72660eeb2218bb98eec92853c6c"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-6.2.2.tgz#beb5fd751355e72660eeb2218bb98eec92853c6c"
   integrity sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA==
 
 makeerror@1.0.x:
@@ -11147,7 +11147,7 @@ merge2@^1.2.3, merge2@^1.3.0:
 
 messageformat-parser@^4.1.3:
   version "4.1.3"
-  resolved "http://localhost:4873/messageformat-parser/-/messageformat-parser-4.1.3.tgz#b824787f57fcda7d50769f5b63e8d4fda68f5b9e"
+  resolved "https://registry.yarnpkg.com/messageformat-parser/-/messageformat-parser-4.1.3.tgz#b824787f57fcda7d50769f5b63e8d4fda68f5b9e"
   integrity sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg==
 
 methods@~1.1.2:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2720,6 +2720,23 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
+"@lingui/core@^3.8.9":
+  version "3.8.9"
+  resolved "https://registry.yarnpkg.com/@lingui/core/-/core-3.8.9.tgz#e520cba3c5eacebb6f378f0e322ce60558ce87ce"
+  integrity sha512-QmEfgukR7w/4/4USZT0LGNt7Yq/RgirFl4088wEta0vgroidxaCRgUXr8RXcdFVjTdtG5dc86JTEj4inZECKvg==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    make-plural "^6.2.2"
+    messageformat-parser "^4.1.3"
+
+"@lingui/react@^3.8.9":
+  version "3.8.9"
+  resolved "https://registry.yarnpkg.com/@lingui/react/-/react-3.8.9.tgz#b0e76796a7b527d792dec6469d7ed45b52ca1db0"
+  integrity sha512-sSiXgUqYBZVGeLwx1vu9XZFgqlJLqTJKEKxltyvo9W53+iKMJWG1YuL6a/eEaOaa5bgJoL3vgDVdub8iBR4M5w==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@lingui/core" "^3.8.9"
+
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-1.1.0.tgz#a62d8ed1cd7e7d4c11d9d52a8397460b5d4ad29f"
@@ -10926,6 +10943,11 @@ make-fetch-happen@^5.0.0:
     socks-proxy-agent "^4.0.0"
     ssri "^6.0.0"
 
+make-plural@^6.2.2:
+  version "6.2.2"
+  resolved "http://localhost:4873/make-plural/-/make-plural-6.2.2.tgz#beb5fd751355e72660eeb2218bb98eec92853c6c"
+  integrity sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -11122,6 +11144,11 @@ merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+messageformat-parser@^4.1.3:
+  version "4.1.3"
+  resolved "http://localhost:4873/messageformat-parser/-/messageformat-parser-4.1.3.tgz#b824787f57fcda7d50769f5b63e8d4fda68f5b9e"
+  integrity sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg==
 
 methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This adds i18n support to the default interface. The core is not touched by this change.

The idea was to go for a very dump `<Trans/>` component that later can be replaced via react-intl, react-i18next or lingui.js.

Unfortunately we need proper translation transforms and replacements straight at the beginning. Thats why we now integrate lingui.js and the user can pass their own instance of lingui.js to provide copy for other locales.

This change also gives us the option to easily override the default copy in case your project needs only the english language.